### PR TITLE
Freeze infra dependencies `setuptools` `pip` and `wheel`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,9 @@ RUN sed -i '/imklog/ s/^/#/' /etc/rsyslog.conf
 
 RUN git config --global url."https://github.com".insteadOf git://github.com
 
-RUN python3 -m pip install --upgrade pip setuptools wheel
+RUN python3 -m pip install setuptools==60.2.0
+RUN python3 -m pip install pip==21.3.1
+RUN python3 -m pip install wheel==0.37.1
 RUN python3 -m pip install https://github.com/kytos-ng/python-openflow/archive/master.zip
 RUN python3 -m pip install https://github.com/kytos-ng/kytos-utils/archive/master.zip
 RUN python3 -m pip install https://github.com/kytos-ng/kytos/archive/master.zip

--- a/Dockerfile-prod
+++ b/Dockerfile-prod
@@ -7,7 +7,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 	&& apt-get clean \
 	&& rm -rf /var/lib/apt/lists/*
 
-RUN python3 -m pip install --upgrade pip setuptools wheel
+RUN python3 -m pip install setuptools==60.2.0
+RUN python3 -m pip install pip==21.3.1
+RUN python3 -m pip install wheel==0.37
 RUN python3 -m pip install https://github.com/kytos-ng/python-openflow/archive/master.zip
 RUN python3 -m pip install https://github.com/kytos-ng/kytos-utils/archive/master.zip
 RUN python3 -m pip install https://github.com/kytos-ng/kytos/archive/master.zip


### PR DESCRIPTION
Fixes #4 

### Description of the change

This PR freezes infra dependencies `setuptools` `pip` and `wheel`, to avoid fetching unwanted or breaking (unstable) dependencies from upstream, we still need to figure out the strategy we'll go for (@italovalcy has raised some points regarding branch/tag versions of NApps, but we haven't prioritized that yet), let me now what you think and your suggestions, I suppose bumping these as needed with a certain frequency should suffice.


**Heads up**:

- Notice with this commit it still  won't build successfully until [mef_eline PR #115 lands](https://github.com/kytos-ng/mef_eline/pull/115), if you apply this patch in the meantime to test it out it works:

```
diff --git a/Dockerfile b/Dockerfile
index afe179c..bd707df 100644
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ RUN python3 -m pip install -e git+https://github.com/kytos-ng/flow_manager#egg=k
 RUN python3 -m pip install -e git+https://github.com/kytos-ng/topology#egg=kytos-topology
 RUN python3 -m pip install -e git+https://github.com/kytos-ng/of_lldp#egg=kytos-of_lldp
 RUN python3 -m pip install -e git+https://github.com/kytos-ng/pathfinder#egg=kytos-pathfinder
-RUN python3 -m pip install -e git+https://github.com/kytos-ng/mef_eline#egg=kytos-mef_eline
+RUN python3 -m pip install -e git+https://github.com/kytos-ng/mef_eline@fix/install_req_deps#egg=kytos-mef_eline
 RUN python3 -m pip install -e git+https://github.com/kytos-ng/maintenance#egg=kytos-maintenance
 RUN python3 -m pip install -e git+https://github.com/amlight/coloring#egg=amlight-coloring
 RUN python3 -m pip install -e git+https://github.com/amlight/sdntrace#egg=amlight-sdntrace
diff --git a/Dockerfile-prod b/Dockerfile-prod
index efbbfea..f2f3436 100644
--- a/Dockerfile-prod
+++ b/Dockerfile-prod
@@ -25,7 +25,7 @@ RUN python3 -m pip install -e git+https://github.com/kytos-ng/flow_manager#egg=k
 RUN python3 -m pip install -e git+https://github.com/kytos-ng/topology#egg=kytos-topology
 RUN python3 -m pip install -e git+https://github.com/kytos-ng/of_lldp#egg=kytos-of_lldp
 RUN python3 -m pip install -e git+https://github.com/kytos-ng/pathfinder#egg=kytos-pathfinder
-RUN python3 -m pip install -e git+https://github.com/kytos-ng/mef_eline#egg=kytos-mef_eline
+RUN python3 -m pip install -e git+https://github.com/kytos-ng/mef_eline@fix/install_req_deps#egg=kytos-mef_eline
 RUN python3 -m pip install -e git+https://github.com/kytos-ng/maintenance#egg=kytos-maintenance
 RUN python3 -m pip install -e git+https://github.com/amlight/coloring#egg=amlight-coloring
 RUN python3 -m pip install -e git+https://github.com/amlight/sdntrace#egg=amlight-sdntrace
```

@italovalcy as I was pinning this branch version to test this, maybe one potential ideal would be to also parametrize with docker variables which branch/tag should the NApp be built with and falling back with `master` for the nightly build, wdyt? That way also enabling developers to one day parametrize the docker build image as well when running the CI, and also, the ops team could pin whichever NApp version is considered stable. Let me know if we should map this or if you already got a doc collecting requirements for this.


