### PR TITLE
Add build-args to parametrize the branch for core and Napps

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,20 @@
 FROM debian:buster-slim
 MAINTAINER Italo Valcy <italovalcy@gmail.com>
 
+ARG branch_python_openflow=master
+ARG branch_kytos_utils=master
+ARG branch_kytos=master
+ARG branch_storehouse=master
+ARG branch_of_core=master
+ARG branch_flow_manager=master
+ARG branch_topology=master
+ARG branch_of_lldp=master
+ARG branch_pathfinder=master
+ARG branch_mef_eline=master
+ARG branch_maintenance=master
+ARG branch_coloring=master
+ARG branch_sdntrace=master
+
 RUN apt-get update && apt-get install -y --no-install-recommends \
 	python3-setuptools python3-pip rsyslog iproute2 procps curl jq git-core patch \
         openvswitch-switch mininet iputils-ping vim tmux less \
@@ -15,20 +29,21 @@ RUN git config --global url."https://github.com".insteadOf git://github.com
 RUN python3 -m pip install setuptools==60.2.0
 RUN python3 -m pip install pip==21.3.1
 RUN python3 -m pip install wheel==0.37.1
-RUN python3 -m pip install https://github.com/kytos-ng/python-openflow/archive/master.zip
-RUN python3 -m pip install https://github.com/kytos-ng/kytos-utils/archive/master.zip
-RUN python3 -m pip install https://github.com/kytos-ng/kytos/archive/master.zip
 
-RUN python3 -m pip install -e git+https://github.com/kytos-ng/storehouse#egg=kytos-storehouse
-RUN python3 -m pip install -e git+https://github.com/kytos-ng/of_core#egg=kytos-of_core
-RUN python3 -m pip install -e git+https://github.com/kytos-ng/flow_manager#egg=kytos-flow_manager
-RUN python3 -m pip install -e git+https://github.com/kytos-ng/topology#egg=kytos-topology
-RUN python3 -m pip install -e git+https://github.com/kytos-ng/of_lldp#egg=kytos-of_lldp
-RUN python3 -m pip install -e git+https://github.com/kytos-ng/pathfinder#egg=kytos-pathfinder
-RUN python3 -m pip install -e git+https://github.com/kytos-ng/mef_eline#egg=kytos-mef_eline
-RUN python3 -m pip install -e git+https://github.com/kytos-ng/maintenance#egg=kytos-maintenance
-RUN python3 -m pip install -e git+https://github.com/amlight/coloring#egg=amlight-coloring
-RUN python3 -m pip install -e git+https://github.com/amlight/sdntrace#egg=amlight-sdntrace
+RUN python3 -m pip install https://github.com/kytos-ng/python-openflow/archive/${branch_python_openflow}.zip \
+ && python3 -m pip install https://github.com/kytos-ng/kytos-utils/archive/${branch_kytos_utils}.zip \
+ && python3 -m pip install https://github.com/kytos-ng/kytos/archive/${branch_kytos}.zip
+
+RUN python3 -m pip install -e git+https://github.com/kytos-ng/storehouse@${branch_storehouse}#egg=kytos-storehouse \
+ && python3 -m pip install -e git+https://github.com/kytos-ng/of_core@${branch_of_core}#egg=kytos-of_core \
+ && python3 -m pip install -e git+https://github.com/kytos-ng/flow_manager@${branch_flow_manager}#egg=kytos-flow_manager \
+ && python3 -m pip install -e git+https://github.com/kytos-ng/topology@${branch_topology}#egg=kytos-topology \
+ && python3 -m pip install -e git+https://github.com/kytos-ng/of_lldp@${branch_of_lldp}#egg=kytos-of_lldp \
+ && python3 -m pip install -e git+https://github.com/kytos-ng/pathfinder@${branch_pathfinder}#egg=kytos-pathfinder \
+ && python3 -m pip install -e git+https://github.com/kytos-ng/mef_eline@${branch_mef_eline}#egg=kytos-mef_eline \
+ && python3 -m pip install -e git+https://github.com/kytos-ng/maintenance@${branch_maintenance}#egg=kytos-maintenance \
+ && python3 -m pip install -e git+https://github.com/amlight/coloring@${branch_coloring}#egg=amlight-coloring \
+ && python3 -m pip install -e git+https://github.com/amlight/sdntrace@${branch_sdntrace}#egg=amlight-sdntrace
 
 # disable sdntrace and coloring by default, you can enable them again by running:
 # 	kytos napps enable amlight/coloring

--- a/Dockerfile-prod
+++ b/Dockerfile-prod
@@ -1,6 +1,20 @@
 FROM debian:buster-slim
 MAINTAINER Italo Valcy <italo@amlight.net>
 
+ARG branch_python_openflow=master
+ARG branch_kytos_utils=master
+ARG branch_kytos=master
+ARG branch_storehouse=master
+ARG branch_of_core=master
+ARG branch_flow_manager=master
+ARG branch_topology=master
+ARG branch_of_lldp=master
+ARG branch_pathfinder=master
+ARG branch_mef_eline=master
+ARG branch_maintenance=master
+ARG branch_coloring=master
+ARG branch_sdntrace=master
+
 RUN apt-get update && apt-get install -y --no-install-recommends \
 	python3-setuptools patch python3-pip iproute2 procps curl git-core \
         vim jq less tmux nginx \
@@ -10,25 +24,26 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 RUN python3 -m pip install setuptools==60.2.0
 RUN python3 -m pip install pip==21.3.1
 RUN python3 -m pip install wheel==0.37
-RUN python3 -m pip install https://github.com/kytos-ng/python-openflow/archive/master.zip
-RUN python3 -m pip install https://github.com/kytos-ng/kytos-utils/archive/master.zip
-RUN python3 -m pip install https://github.com/kytos-ng/kytos/archive/master.zip
+
+RUN python3 -m pip install https://github.com/kytos-ng/python-openflow/archive/${branch_python_openflow}.zip \
+ && python3 -m pip install https://github.com/kytos-ng/kytos-utils/archive/${branch_kytos_utils}.zip \
+ && python3 -m pip install https://github.com/kytos-ng/kytos/archive/${branch_kytos}.zip
 
 COPY kytos.conf /etc/kytos/
 COPY logging.ini /etc/kytos/
 RUN sed -i "s/XXXJWTSECRETXXX/$(python3 -c 'import secrets; print(secrets.token_hex(16))')/g" /etc/kytos/kytos.conf
 RUN mkdir /var/log/kytos && touch /var/log/kytos/kytos-error.log /var/log/kytos/kytos.log
 
-RUN python3 -m pip install -e git+https://github.com/kytos-ng/storehouse#egg=kytos-storehouse
-RUN python3 -m pip install -e git+https://github.com/kytos-ng/of_core#egg=kytos-of_core
-RUN python3 -m pip install -e git+https://github.com/kytos-ng/flow_manager#egg=kytos-flow_manager
-RUN python3 -m pip install -e git+https://github.com/kytos-ng/topology#egg=kytos-topology
-RUN python3 -m pip install -e git+https://github.com/kytos-ng/of_lldp#egg=kytos-of_lldp
-RUN python3 -m pip install -e git+https://github.com/kytos-ng/pathfinder#egg=kytos-pathfinder
-RUN python3 -m pip install -e git+https://github.com/kytos-ng/mef_eline#egg=kytos-mef_eline
-RUN python3 -m pip install -e git+https://github.com/kytos-ng/maintenance#egg=kytos-maintenance
-RUN python3 -m pip install -e git+https://github.com/amlight/coloring#egg=amlight-coloring
-RUN python3 -m pip install -e git+https://github.com/amlight/sdntrace#egg=amlight-sdntrace
+RUN python3 -m pip install -e git+https://github.com/kytos-ng/storehouse@${branch_storehouse}#egg=kytos-storehouse \
+ && python3 -m pip install -e git+https://github.com/kytos-ng/of_core@${branch_of_core}#egg=kytos-of_core \
+ && python3 -m pip install -e git+https://github.com/kytos-ng/flow_manager@${branch_flow_manager}#egg=kytos-flow_manager \
+ && python3 -m pip install -e git+https://github.com/kytos-ng/topology@${branch_topology}#egg=kytos-topology \
+ && python3 -m pip install -e git+https://github.com/kytos-ng/of_lldp@${branch_of_lldp}#egg=kytos-of_lldp \
+ && python3 -m pip install -e git+https://github.com/kytos-ng/pathfinder@${branch_pathfinder}#egg=kytos-pathfinder \
+ && python3 -m pip install -e git+https://github.com/kytos-ng/mef_eline@${branch_mef_eline}#egg=kytos-mef_eline \
+ && python3 -m pip install -e git+https://github.com/kytos-ng/maintenance@${branch_maintenance}#egg=kytos-maintenance \
+ && python3 -m pip install -e git+https://github.com/amlight/coloring@${branch_coloring}#egg=amlight-coloring \
+ && python3 -m pip install -e git+https://github.com/amlight/sdntrace@${branch_sdntrace}#egg=amlight-sdntrace
 
 COPY ./apply-patches.sh  /tmp/
 COPY ./patches /tmp/patches

--- a/README.md
+++ b/README.md
@@ -4,6 +4,20 @@
 
 **NOTE: Since Kytos project is in a "shutdown" phase, our docker image is based on the fork of the project - Kytos-NG (https://github.com/kytos-ng). The naming convention inside the docker image remains the same, but eventually they will be changed to kytos-ng in the future.**
 
+## Build
+
+You can build the docker image by just running:
+
+       docker build -f Dockerfile --no-cache -t amlight/kytos .
+
+You can also use some build arguments to specify which branch should be used on each component (core and Napps):
+
+       docker build -f Dockerfile --build-arg branch_mef_eline=fix/issue_xpto --build-arg branch_kytos_utils=fix/error_foobar -t amlight/kytos .
+
+When running in a CI/CD with environment variables:
+
+       env | grep ^branch_ | sed -e 's/^/--build-arg /' | xargs docker build -f Dockerfile --no-cache -t amlight/kytos .
+
 ## Usage
 
 After pull or build the image, you can run:


### PR DESCRIPTION
Fixes #6 

### Description of the change

This PR adds a few build arguments to the docker files so that the branch/tags for core and Napps can be parametrized. This change will allow someone to build a docker image using different versions other than the master branch, making it easier to run more tests before opening/merging a pull request.

Comments were added to the README file to show examples of how to use the arguments. We will adjust our CI/CD tool to benefit from the build arguments as soon as this PR lands.

Preliminary tests were run to make sure the change didn't break any code:
```
$ docker build -f Dockerfile --no-cache --build-arg branch_of_lldp=feature/set_cookie --build-arg branch_topology=fix/install_req_deps .
Sending build context to Docker daemon  594.4kB
Step 1/33 : FROM debian:buster-slim
 ---> 80b9e7aadac5
...
Obtaining kytos-topology from git+https://github.com/kytos-ng/topology@fix/install_req_deps#egg=kytos-topology
  Cloning https://github.com/kytos-ng/topology (to revision fix/install_req_deps) to /src/kytos-topology
  Running command git clone --filter=blob:none -q https://github.com/kytos-ng/topology /src/kytos-topology
  Running command git checkout -b fix/install_req_deps --track origin/fix/install_req_deps
  Switched to a new branch 'fix/install_req_deps'
  Branch 'fix/install_req_deps' set up to track remote branch 'fix/install_req_deps' from 'origin'.
...
Obtaining kytos-of_lldp from git+https://github.com/kytos-ng/of_lldp@feature/set_cookie#egg=kytos-of_lldp
  Cloning https://github.com/kytos-ng/of_lldp (to revision feature/set_cookie) to /src/kytos-of-lldp
  Running command git clone --filter=blob:none -q https://github.com/kytos-ng/of_lldp /src/kytos-of-lldp
  Running command git checkout -b feature/set_cookie --track origin/feature/set_cookie
  Switched to a new branch 'feature/set_cookie'
  Branch 'feature/set_cookie' set up to track remote branch 'feature/set_cookie' from 'origin'.
...
Step 33/33 : ENTRYPOINT ["/docker-entrypoint.sh"]
 ---> Running in b75a4f23f0a5
Removing intermediate container b75a4f23f0a5
 ---> de875e7cb892
Successfully built de875e7cb892
```

### Release notes

 - Added build arguments to allow choosing which branch/tag to use (Kytos core and Napps) when building the docker image