### PR TITLE
Adding amlight/sdntrace-cp napp and fix apply-patches script

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,9 @@ ARG branch_mef_eline=master
 ARG branch_maintenance=master
 ARG branch_coloring=master
 ARG branch_sdntrace=master
+ARG branch_scheduler=master
+ARG branch_flow_stats=master
+ARG branch_sdntrace_cp=master
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
 	python3-setuptools python3-pip rsyslog iproute2 procps curl jq git-core patch \
@@ -43,7 +46,10 @@ RUN python3 -m pip install -e git+https://github.com/kytos-ng/storehouse@${branc
  && python3 -m pip install -e git+https://github.com/kytos-ng/mef_eline@${branch_mef_eline}#egg=kytos-mef_eline \
  && python3 -m pip install -e git+https://github.com/kytos-ng/maintenance@${branch_maintenance}#egg=kytos-maintenance \
  && python3 -m pip install -e git+https://github.com/amlight/coloring@${branch_coloring}#egg=amlight-coloring \
- && python3 -m pip install -e git+https://github.com/amlight/sdntrace@${branch_sdntrace}#egg=amlight-sdntrace
+ && python3 -m pip install -e git+https://github.com/amlight/sdntrace@${branch_sdntrace}#egg=amlight-sdntrace \
+ && python3 -m pip install -e git+https://github.com/amlight/scheduler@${branch_scheduler}#egg=amlight-scheduler \
+ && python3 -m pip install -e git+https://github.com/amlight/flow_stats@${branch_flow_stats}#egg=amlight-flow_stats \
+ && python3 -m pip install -e git+https://github.com/amlight/sdntrace_cp@${branch_sdntrace_cp}#egg=amlight-sdntrace_cp
 
 # disable sdntrace and coloring by default, you can enable them again by running:
 # 	kytos napps enable amlight/coloring

--- a/Dockerfile
+++ b/Dockerfile
@@ -51,11 +51,14 @@ RUN python3 -m pip install -e git+https://github.com/kytos-ng/storehouse@${branc
  && python3 -m pip install -e git+https://github.com/amlight/flow_stats@${branch_flow_stats}#egg=amlight-flow_stats \
  && python3 -m pip install -e git+https://github.com/amlight/sdntrace_cp@${branch_sdntrace_cp}#egg=amlight-sdntrace_cp
 
-# disable sdntrace and coloring by default, you can enable them again by running:
-# 	kytos napps enable amlight/coloring
+# disable sdntrace and sdntrace_cp by default (along with their deps), you can enable them again by running:
 #	kytos napps enable amlight/sdntrace
+# 	kytos napps enable amlight/sdntrace_cp
 RUN unlink /var/lib/kytos/napps/amlight/coloring
 RUN unlink /var/lib/kytos/napps/amlight/sdntrace
+RUN unlink /var/lib/kytos/napps/amlight/scheduler
+RUN unlink /var/lib/kytos/napps/amlight/flow_stats
+RUN unlink /var/lib/kytos/napps/amlight/sdntrace_cp
 
 COPY ./apply-patches.sh  /tmp/
 COPY ./patches /tmp/patches

--- a/Dockerfile-prod
+++ b/Dockerfile-prod
@@ -14,6 +14,9 @@ ARG branch_mef_eline=master
 ARG branch_maintenance=master
 ARG branch_coloring=master
 ARG branch_sdntrace=master
+ARG branch_scheduler=master
+ARG branch_flow_stats=master
+ARG branch_sdntrace_cp=master
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
 	python3-setuptools patch python3-pip iproute2 procps curl git-core \
@@ -43,7 +46,10 @@ RUN python3 -m pip install -e git+https://github.com/kytos-ng/storehouse@${branc
  && python3 -m pip install -e git+https://github.com/kytos-ng/mef_eline@${branch_mef_eline}#egg=kytos-mef_eline \
  && python3 -m pip install -e git+https://github.com/kytos-ng/maintenance@${branch_maintenance}#egg=kytos-maintenance \
  && python3 -m pip install -e git+https://github.com/amlight/coloring@${branch_coloring}#egg=amlight-coloring \
- && python3 -m pip install -e git+https://github.com/amlight/sdntrace@${branch_sdntrace}#egg=amlight-sdntrace
+ && python3 -m pip install -e git+https://github.com/amlight/sdntrace@${branch_sdntrace}#egg=amlight-sdntrace \
+ && python3 -m pip install -e git+https://github.com/amlight/scheduler@${branch_scheduler}#egg=amlight-scheduler \
+ && python3 -m pip install -e git+https://github.com/amlight/flow_stats@${branch_flow_stats}#egg=amlight-flow_stats \
+ && python3 -m pip install -e git+https://github.com/amlight/sdntrace_cp@${branch_sdntrace_cp}#egg=amlight-sdntrace_cp
 
 COPY ./apply-patches.sh  /tmp/
 COPY ./patches /tmp/patches

--- a/apply-patches.sh
+++ b/apply-patches.sh
@@ -19,8 +19,9 @@ cd $ORIG_DIR
 for NAPP in $(ls -1 patches/napps/); do
 	echo $NAPP
 	NAPP_DIR=$(python3 -m pip show $NAPP | grep Location | awk '{print $NF}')
+	test -z "$NAPP_DIR" && NAPP_DIR=/src/$(echo $NAPP | tr '_' '-')
 	cd $NAPP_DIR
-	for PATCH in $(find $ORIG_DIR/patches/napps/$NAPP/ -type f -name '*.patch'); do
+	for PATCH in $(find $ORIG_DIR/patches/napps/$NAPP/ -type f -name '*.patch' | sort); do
 		echo $PATCH
 		$PATCH_BIN -p1 < $PATCH
 	done


### PR DESCRIPTION
This PR was built on top of PR #7. Thus, PR #7 needs to land first.

### Description of the change

This PR adds the Napp amlight/sdntrace-cp to the docker images. The napp sdntrace-cp is a dependency for kytos/mef_eline and it is used to make sure the EVC is active as part of mef_eline's consistency check.

This PR also fixes the finding Napps directory approach. Since Napps are not listed from `pip list`, we fall back to the `/src/xxx` folder.

### Release notes

- Added amlight/sdntrace-cp Napp