### PR TITLE
[Feature] Upgrade base image to bullseye-slim to use Python 3.9.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:buster-slim
+FROM debian:bullseye-slim
 MAINTAINER Italo Valcy <italovalcy@gmail.com>
 
 ARG branch_python_openflow=master
@@ -18,7 +18,6 @@ ARG branch_sdntrace=master
 RUN apt-get update && apt-get install -y --no-install-recommends \
 	python3-setuptools python3-pip rsyslog iproute2 procps curl jq git-core patch \
         openvswitch-switch mininet iputils-ping vim tmux less \
-        python-pytest python-requests python-mock python-pytest-timeout \
 	&& apt-get clean \
 	&& rm -rf /var/lib/apt/lists/*
 
@@ -44,6 +43,12 @@ RUN python3 -m pip install -e git+https://github.com/kytos-ng/storehouse@${branc
  && python3 -m pip install -e git+https://github.com/kytos-ng/maintenance@${branch_maintenance}#egg=kytos-maintenance \
  && python3 -m pip install -e git+https://github.com/amlight/coloring@${branch_coloring}#egg=amlight-coloring \
  && python3 -m pip install -e git+https://github.com/amlight/sdntrace@${branch_sdntrace}#egg=amlight-sdntrace
+
+# end-to-end python related dependencies
+RUN python3 -m pip install pytest-timeout==2.0.2 \
+ && python3 -m pip install pytest==6.2.5 \
+ && python3 -m pip install mock==4.0.3 \
+ && python3 -m pip install requests # resolve to same version as NApps
 
 # disable sdntrace and coloring by default, you can enable them again by running:
 # 	kytos napps enable amlight/coloring

--- a/Dockerfile-prod
+++ b/Dockerfile-prod
@@ -1,4 +1,4 @@
-FROM debian:buster-slim
+FROM debian:bullseye-slim
 MAINTAINER Italo Valcy <italo@amlight.net>
 
 ARG branch_python_openflow=master


### PR DESCRIPTION

This is for upgrading the base image to `debian:bullseye` to use `Python 3.9.2`, I also moved some of the `apt-get install python-*` to install via `pip` since that package name has changed on `debian:bullseye`. @italovalcy with `bullseye` as we briefly chatted, the issue of collecting and installing `zipp>=0.5` doesn't happen anymore. 

- Building successfully `Dockerfile`:

```
docker build -f Dockerfile --no-cache . -t amlight/kytos:dev

Sending build context to Docker daemon  707.6kB
Step 1/34 : FROM debian:bullseye-slim
 ---> 8bca477113bd
Step 2/34 : MAINTAINER Italo Valcy <italovalcy@gmail.com>
 ---> Running in a42e44474b79
....
Removing intermediate container 9bef34791ba1
 ---> f5cbdf89489e
Successfully built f5cbdf89489e
Successfully tagged amlight/kytos:dev
```

- Building successfully `Dockerfile-prod`:

```
docker build -f Dockerfile-prod --no-cache -t amlight/kytos:prod .

Step 1/35 : FROM debian:bullseye-slim
 ---> 8bca477113bd
Step 2/35 : MAINTAINER Italo Valcy <italo@amlight.net>
 ---> Running in cb7153904c1e
Removing intermediate container cb7153904c1e
...

Removing intermediate container e516e2477e63
 ---> b9da4603122c
Successfully built b9da4603122c
Successfully tagged amlight/kytos:prod
```