### PR TITLE
pip install pymongo on testing Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -51,11 +51,12 @@ RUN python3 -m pip install -e git+https://github.com/kytos-ng/storehouse@${branc
  && python3 -m pip install -e git+https://github.com/amlight/sdntrace_cp@${branch_sdntrace_cp}#egg=amlight-sdntrace_cp
 
 # end-to-end python related dependencies
+# pymongo and requests resolve to the same version on kytos and NApps
 RUN python3 -m pip install pytest-timeout==2.0.2 \
  && python3 -m pip install pytest==6.2.5 \
  && python3 -m pip install mock==4.0.3 \
- && python3 -m pip install pymongo==4.0.2 \
- && python3 -m pip install requests # resolve to same version as NApps
+ && python3 -m pip install pymongo \
+ && python3 -m pip install requests
 
 COPY ./apply-patches.sh  /tmp/
 COPY ./patches /tmp/patches

--- a/Dockerfile
+++ b/Dockerfile
@@ -54,6 +54,7 @@ RUN python3 -m pip install -e git+https://github.com/kytos-ng/storehouse@${branc
 RUN python3 -m pip install pytest-timeout==2.0.2 \
  && python3 -m pip install pytest==6.2.5 \
  && python3 -m pip install mock==4.0.3 \
+ && python3 -m pip install pymongo==4.0.2 \
  && python3 -m pip install requests # resolve to same version as NApps
 
 COPY ./apply-patches.sh  /tmp/


### PR DESCRIPTION
Fixes #12 

`pymongo==4.0.2` is the latest stable version we're planning to go with, we need this testing dependency to clean up the database between tests teardown. At the moment, the version is pinned, but once `kytos` ships with it, then we should be able to unpin in the same [way we've done for `requests`](https://github.com/amlight/kytos-docker/blob/master/Dockerfile#L57), since we'd have strong guarantees from our trusted repos that it'll be pinned there, so it will resolve correctly. 

Here's a successful build that I've been running and testing locally:

`docker build -f Dockerfile --no-cache --build-arg branch_topology=feature/mongo  . -t amlight/kytos:dev`

```
....

Removing intermediate container bf80df5e3ab8
 ---> 3c8318ff9a30
Successfully built 3c8318ff9a30
Successfully tagged amlight/kytos:dev
```