### PR TITLE
Updated amlight to kytos-ng org git url on Dockerfiles

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,11 +44,11 @@ RUN python3 -m pip install -e git+https://github.com/kytos-ng/storehouse@${branc
  && python3 -m pip install -e git+https://github.com/kytos-ng/pathfinder@${branch_pathfinder}#egg=kytos-pathfinder \
  && python3 -m pip install -e git+https://github.com/kytos-ng/mef_eline@${branch_mef_eline}#egg=kytos-mef_eline \
  && python3 -m pip install -e git+https://github.com/kytos-ng/maintenance@${branch_maintenance}#egg=kytos-maintenance \
- && python3 -m pip install -e git+https://github.com/amlight/coloring@${branch_coloring}#egg=amlight-coloring \
- && python3 -m pip install -e git+https://github.com/amlight/sdntrace@${branch_sdntrace}#egg=amlight-sdntrace \
- && python3 -m pip install -e git+https://github.com/amlight/scheduler@${branch_scheduler}#egg=amlight-scheduler \
- && python3 -m pip install -e git+https://github.com/amlight/flow_stats@${branch_flow_stats}#egg=amlight-flow_stats \
- && python3 -m pip install -e git+https://github.com/amlight/sdntrace_cp@${branch_sdntrace_cp}#egg=amlight-sdntrace_cp
+ && python3 -m pip install -e git+https://github.com/kytos-ng/coloring@${branch_coloring}#egg=amlight-coloring \
+ && python3 -m pip install -e git+https://github.com/kytos-ng/sdntrace@${branch_sdntrace}#egg=amlight-sdntrace \
+ && python3 -m pip install -e git+https://github.com/kytos-ng/scheduler@${branch_scheduler}#egg=amlight-scheduler \
+ && python3 -m pip install -e git+https://github.com/kytos-ng/flow_stats@${branch_flow_stats}#egg=amlight-flow_stats \
+ && python3 -m pip install -e git+https://github.com/kytos-ng/sdntrace_cp@${branch_sdntrace_cp}#egg=amlight-sdntrace_cp
 
 # end-to-end python related dependencies
 # pymongo and requests resolve to the same version on kytos and NApps

--- a/Dockerfile-prod
+++ b/Dockerfile-prod
@@ -45,11 +45,11 @@ RUN python3 -m pip install -e git+https://github.com/kytos-ng/storehouse@${branc
  && python3 -m pip install -e git+https://github.com/kytos-ng/pathfinder@${branch_pathfinder}#egg=kytos-pathfinder \
  && python3 -m pip install -e git+https://github.com/kytos-ng/mef_eline@${branch_mef_eline}#egg=kytos-mef_eline \
  && python3 -m pip install -e git+https://github.com/kytos-ng/maintenance@${branch_maintenance}#egg=kytos-maintenance \
- && python3 -m pip install -e git+https://github.com/amlight/coloring@${branch_coloring}#egg=amlight-coloring \
- && python3 -m pip install -e git+https://github.com/amlight/sdntrace@${branch_sdntrace}#egg=amlight-sdntrace \
- && python3 -m pip install -e git+https://github.com/amlight/scheduler@${branch_scheduler}#egg=amlight-scheduler \
- && python3 -m pip install -e git+https://github.com/amlight/flow_stats@${branch_flow_stats}#egg=amlight-flow_stats \
- && python3 -m pip install -e git+https://github.com/amlight/sdntrace_cp@${branch_sdntrace_cp}#egg=amlight-sdntrace_cp
+ && python3 -m pip install -e git+https://github.com/kytos-ng/coloring@${branch_coloring}#egg=amlight-coloring \
+ && python3 -m pip install -e git+https://github.com/kytos-ng/sdntrace@${branch_sdntrace}#egg=amlight-sdntrace \
+ && python3 -m pip install -e git+https://github.com/kytos-ng/scheduler@${branch_scheduler}#egg=amlight-scheduler \
+ && python3 -m pip install -e git+https://github.com/kytos-ng/flow_stats@${branch_flow_stats}#egg=amlight-flow_stats \
+ && python3 -m pip install -e git+https://github.com/kytos-ng/sdntrace_cp@${branch_sdntrace_cp}#egg=amlight-sdntrace_cp
 
 COPY ./apply-patches.sh  /tmp/
 COPY ./patches /tmp/patches


### PR DESCRIPTION
@rmotitsuki has helped us to transfer the org ownership of some amlight NApps to kytos-ng, the old urls keep compatible but to avoid surprises this updates the Dockerfiles accordingly, since I was building images to test other features on GitLab CI that I'm developing I took the opportunity to open this PR. 

```

❯ docker build -f Dockerfile --no-cache --build-arg branch_topology=feature/mongo_retries --build-arg branch_kytos=feature/apm --build-arg branch_coloring=some_branch  . -t amlight/kytos:dev

...
Removing intermediate container 0c8f6d7fb0b7
 ---> fe14fcfd6c3d
Successfully built fe14fcfd6c3d
Successfully tagged amlight/kytos:dev
...

❯ docker build -f Dockerfile-prod --no-cache --build-arg branch_topology=feature/mongo_retries --build-arg branch_kytos=feature/apm --build-arg branch_coloring=some_branch  . -t amlight/kytos:prod


Step 38/38 : ENTRYPOINT ["/docker-entrypoint.sh"]
 ---> Running in 7b2bd1ae4b9f
Removing intermediate container 7b2bd1ae4b9f
 ---> c5733022c802
Successfully built c5733022c802
Successfully tagged amlight/kytos:prod


```