### PR TITLE
Add rotating capabilities and enhance log format

### DIFF
--- a/logging.ini
+++ b/logging.ini
@@ -8,17 +8,17 @@ keys: file, fileerr
 keys: root
 
 [formatter_file]
-format: %(asctime)s - %(levelname)s [%(name)s] (%(threadName)s) %(message)s
+format: %(asctime)s - %(levelname)s [%(name)s] [%(filename)s:%(lineno)d:%(funcName)s] (%(threadName)s) %(message)s
 
 [handler_file]
-class: FileHandler
-args:["/var/log/kytos/kytos.log"]
+class: handlers.RotatingFileHandler
+args:["/var/log/kytos/kytos.log", "a", 200*1024*1024, 4]
 formatter: file
 level: INFO
 
 [handler_fileerr]
-class: FileHandler
-args:["/var/log/kytos/kytos-error.log"]
+class: handlers.RotatingFileHandler
+args:["/var/log/kytos/kytos-error.log", "a", 100*1024*1024, 4]
 formatter: file
 level: ERROR
 


### PR DESCRIPTION
Fixes #16 
Fixes #15 

### Description of the change

- Adding `handlers.RotatingFileHandler` to make Kytos server robust against disk full errors when excessive log messages are generated (defaults to maximum 1GB for `kytos.log` and 500MB `kytos-error.log`)
- Enhancing log format to include file, line number, and function name. The additional information will help developers/operator quickly find problems during troubleshooting and also will make it compatible with ES searchable logging.

### Release notes

- Enhance Kytos logging capabilities by adding automatic rotation to log files and custom log format including file, lineno and func name