### PR TITLE
[Feat] `pytest-rerunfailures` to help out with false positive asserts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,6 +50,7 @@ RUN python3 -m pip install -e git+https://github.com/kytos-ng/of_core@${branch_o
 # pymongo and requests resolve to the same version on kytos and NApps
 RUN python3 -m pip install pytest-timeout==2.0.2 \
  && python3 -m pip install pytest==6.2.5 \
+ && python3 -m pip install pytest-rerunfailures==10.2 \
  && python3 -m pip install mock==4.0.3 \
  && python3 -m pip install pymongo \
  && python3 -m pip install requests

--- a/Dockerfile
+++ b/Dockerfile
@@ -48,8 +48,8 @@ RUN python3 -m pip install -e git+https://github.com/kytos-ng/of_core@${branch_o
 
 # end-to-end python related dependencies
 # pymongo and requests resolve to the same version on kytos and NApps
-RUN python3 -m pip install pytest-timeout==2.0.2 \
- && python3 -m pip install pytest==6.2.5 \
+RUN python3 -m pip install pytest-timeout==2.1.0 \
+ && python3 -m pip install pytest==7.2.0 \
  && python3 -m pip install pytest-rerunfailures==10.2 \
  && python3 -m pip install mock==4.0.3 \
  && python3 -m pip install pymongo \


### PR DESCRIPTION
I've added [`pytest-rerunfailures==10.2`](https://github.com/pytest-dev/pytest-rerunfailures), and upgraded `pytest` and `pytest-timeout`, this is an experiment to play with one of the ideas mentioned in this issue https://github.com/amlight/kytos-end-to-end-tests/issues/155. 

I'm running more e2e tests, it'd be great that if an assertion has a false positive then this plugin auto retries, but still reports the re-run just so any potential renaming flaky test or bug can still be analyzed incrementally accordingly, that way facilitating for our team to understand if a test case failure is intermittent or not. I'll leave this in draft in the meantime, I'll dispatch more executions.