### PR TITLE
feat: add the kytos UI download as part of the docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,8 @@ ARG branch_coloring=master
 ARG branch_sdntrace=master
 ARG branch_flow_stats=master
 ARG branch_sdntrace_cp=master
+# USAGE: ... --build-arg release_ui=download/2022.2.0 ...
+ARG release_ui=latest/download
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
 	python3-setuptools python3-pip rsyslog iproute2 procps curl jq git-core patch \
@@ -44,7 +46,10 @@ RUN python3 -m pip install -e git+https://github.com/kytos-ng/of_core@${branch_o
  && python3 -m pip install -e git+https://github.com/kytos-ng/sdntrace@${branch_sdntrace}#egg=amlight-sdntrace \
  && python3 -m pip install -e git+https://github.com/kytos-ng/flow_stats@${branch_flow_stats}#egg=amlight-flow_stats \
  && python3 -m pip install -e git+https://github.com/kytos-ng/sdntrace_cp@${branch_sdntrace_cp}#egg=amlight-sdntrace_cp \
- && python3 -m pip install -e git+https://github.com/kytos-ng/mef_eline@${branch_mef_eline}#egg=kytos-mef_eline
+ && python3 -m pip install -e git+https://github.com/kytos-ng/mef_eline@${branch_mef_eline}#egg=kytos-mef_eline \
+ && curl -L -o /tmp/latest.zip https://github.com/kytos-ng/ui/releases/${release_ui}/latest.zip \
+ && python3 -m zipfile -e /tmp/latest.zip  /usr/local/lib/python3.9/dist-packages/kytos/web-ui \
+ && rm -f /tmp/latest.zip
 
 # end-to-end python related dependencies
 # pymongo and requests resolve to the same version on kytos and NApps

--- a/Dockerfile-prod
+++ b/Dockerfile-prod
@@ -15,6 +15,8 @@ ARG branch_coloring=master
 ARG branch_sdntrace=master
 ARG branch_flow_stats=master
 ARG branch_sdntrace_cp=master
+# USAGE: ... --build-arg release_ui=download/2022.2.0 ...
+ARG release_ui=latest/download
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
 	python3-setuptools patch python3-pip iproute2 procps curl git-core \
@@ -45,7 +47,10 @@ RUN python3 -m pip install -e git+https://github.com/kytos-ng/of_core@${branch_o
  && python3 -m pip install -e git+https://github.com/kytos-ng/sdntrace@${branch_sdntrace}#egg=amlight-sdntrace \
  && python3 -m pip install -e git+https://github.com/kytos-ng/flow_stats@${branch_flow_stats}#egg=amlight-flow_stats \
  && python3 -m pip install -e git+https://github.com/kytos-ng/sdntrace_cp@${branch_sdntrace_cp}#egg=amlight-sdntrace_cp \
- && python3 -m pip install -e git+https://github.com/kytos-ng/mef_eline@${branch_mef_eline}#egg=kytos-mef_eline
+ && python3 -m pip install -e git+https://github.com/kytos-ng/mef_eline@${branch_mef_eline}#egg=kytos-mef_eline \
+ && curl -L -o /tmp/latest.zip https://github.com/kytos-ng/ui/releases/${release_ui}/latest.zip \
+ && python3 -m zipfile -e /tmp/latest.zip  /usr/local/lib/python3.9/dist-packages/kytos/web-ui \
+ && rm -f /tmp/latest.zip
 
 COPY ./apply-patches.sh  /tmp/
 COPY ./patches /tmp/patches


### PR DESCRIPTION
Closes N/A

### Summary

Sometimes due to connectivity issues (i.e., local firewall policies or even github instabilities), Kytos fails to download the UI. More critical situations are observed when the github page takes very long time to answer: since the urlretrieve does not provide a timeout parameter, kytos-ng keeps waiting forever.

This PR adds the UI download as part of the docker build process. With the proposed change, `amlight/kytos` docker image will be delivered with the latest UI included, speeding up the startup process. Furthermore, we also provide ways for customizing the UI version through docker build arguments.

### Local tests

Here are some examples of the build process with default arguments and custom UI release:

```
$ docker build -f Dockerfile -t amlight/kytos:latest .
...
 ---> 3eebda648e0e
Successfully built 3eebda648e0e
Successfully tagged amlight/kytos:latest

$ docker build -f Dockerfile -t amlight/kytos:latest --build-arg release_ui=download/2022.3.0 .
...
 ---> 80dc618dcf92
Successfully built 80dc618dcf92
Successfully tagged amlight/kytos:latest
```

### End-to-end tests

N/A