### PR TITLE
chore: removed `flow_stats`, leaving only `kytos_stats` on Docker images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,6 @@ ARG branch_mef_eline=master
 ARG branch_maintenance=master
 ARG branch_coloring=master
 ARG branch_sdntrace=master
-ARG branch_flow_stats=master
 ARG branch_kytos_stats=master
 ARG branch_sdntrace_cp=master
 ARG branch_of_multi_table=master
@@ -46,7 +45,6 @@ RUN python3 -m pip install -e git+https://github.com/kytos-ng/of_core@${branch_o
  && python3 -m pip install -e git+https://github.com/kytos-ng/maintenance@${branch_maintenance}#egg=kytos-maintenance \
  && python3 -m pip install -e git+https://github.com/kytos-ng/coloring@${branch_coloring}#egg=amlight-coloring \
  && python3 -m pip install -e git+https://github.com/kytos-ng/sdntrace@${branch_sdntrace}#egg=amlight-sdntrace \
- && python3 -m pip install -e git+https://github.com/kytos-ng/flow_stats@${branch_flow_stats}#egg=amlight-flow_stats \
  && python3 -m pip install -e git+https://github.com/kytos-ng/kytos_stats@${branch_kytos_stats}#egg=amlight-kytos_stats \
  && python3 -m pip install -e git+https://github.com/kytos-ng/sdntrace_cp@${branch_sdntrace_cp}#egg=amlight-sdntrace_cp \
  && python3 -m pip install -e git+https://github.com/kytos-ng/mef_eline@${branch_mef_eline}#egg=kytos-mef_eline \

--- a/Dockerfile-prod
+++ b/Dockerfile-prod
@@ -13,7 +13,7 @@ ARG branch_mef_eline=master
 ARG branch_maintenance=master
 ARG branch_coloring=master
 ARG branch_sdntrace=master
-ARG branch_flow_stats=master
+ARG branch_kytos_stats=master
 ARG branch_sdntrace_cp=master
 # USAGE: ... --build-arg release_ui=download/2022.2.0 ...
 ARG release_ui=latest/download
@@ -45,7 +45,7 @@ RUN python3 -m pip install -e git+https://github.com/kytos-ng/of_core@${branch_o
  && python3 -m pip install -e git+https://github.com/kytos-ng/maintenance@${branch_maintenance}#egg=kytos-maintenance \
  && python3 -m pip install -e git+https://github.com/kytos-ng/coloring@${branch_coloring}#egg=amlight-coloring \
  && python3 -m pip install -e git+https://github.com/kytos-ng/sdntrace@${branch_sdntrace}#egg=amlight-sdntrace \
- && python3 -m pip install -e git+https://github.com/kytos-ng/flow_stats@${branch_flow_stats}#egg=amlight-flow_stats \
+ && python3 -m pip install -e git+https://github.com/kytos-ng/kytos_stats@${branch_kytos_stats}#egg=amlight-kytos_stats \
  && python3 -m pip install -e git+https://github.com/kytos-ng/sdntrace_cp@${branch_sdntrace_cp}#egg=amlight-sdntrace_cp \
  && python3 -m pip install -e git+https://github.com/kytos-ng/mef_eline@${branch_mef_eline}#egg=kytos-mef_eline \
  && curl -L -o /tmp/latest.zip https://github.com/kytos-ng/ui/releases/${release_ui}/latest.zip \


### PR DESCRIPTION
Closes #31 

### Summary

- removed `flow_stats`, leaving only `kytos_stats` on Docker images

This needs @italovalcy review to make sure that in prod AmLight isn't still using any script that used to depend on `flow_stats`. To recap `kytos_stats` is the successor of `flow_stats` except that the URL prefix has changed. I'll go ahead and leave this PR ready here for Italo when he's back from vacation. 

### End-to-End Tests

It'll be run on another related PR (will be linked)