### PR TITLE
feat: Added kafka_events to list of NApps installed in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ ARG branch_sdntrace=master
 ARG branch_kytos_stats=master
 ARG branch_sdntrace_cp=master
 ARG branch_of_multi_table=master
-ARG branch_kafka_events=main
+ARG branch_kafka_events=master
 # USAGE: ... --build-arg release_ui=download/2022.2.0 ...
 ARG release_ui=latest/download
 
@@ -63,7 +63,6 @@ RUN python3 -m pip install pytest-timeout==2.2.0 \
  && python3 -m pip install pytest-rerunfailures==13.0 \
  && python3 -m pip install mock==5.1.0 \
  && python3 -m pip install pymongo \
- && python3 -m pip install aiokafka==0.12.0 \
  && python3 -m pip install requests
 
 COPY ./apply-patches.sh  /tmp/

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,7 @@ ARG branch_sdntrace=master
 ARG branch_kytos_stats=master
 ARG branch_sdntrace_cp=master
 ARG branch_of_multi_table=master
+ARG branch_kafka_events=main
 # USAGE: ... --build-arg release_ui=download/2022.2.0 ...
 ARG release_ui=latest/download
 
@@ -49,6 +50,7 @@ RUN python3 -m pip install -e git+https://github.com/kytos-ng/of_core@${branch_o
  && python3 -m pip install -e git+https://github.com/kytos-ng/sdntrace_cp@${branch_sdntrace_cp}#egg=amlight-sdntrace_cp \
  && python3 -m pip install -e git+https://github.com/kytos-ng/mef_eline@${branch_mef_eline}#egg=kytos-mef_eline \
  && python3 -m pip install -e git+https://github.com/kytos-ng/of_multi_table@${branch_of_multi_table}#egg=kytos-of_multi_table \
+ && python3 -m pip install -e git+https://github.com/kytos-ng/kafka_events@${branch_kafka_events}#egg=kytos-kafka_events \
  && curl -L -o /tmp/latest.zip https://github.com/kytos-ng/ui/releases/${release_ui}/latest.zip \
  && python3 -m zipfile -e /tmp/latest.zip  /usr/local/lib/python3.11/dist-packages/kytos/web-ui \
  && rm -f /tmp/latest.zip
@@ -57,9 +59,11 @@ RUN python3 -m pip install -e git+https://github.com/kytos-ng/of_core@${branch_o
 # pymongo and requests resolve to the same version on kytos and NApps
 RUN python3 -m pip install pytest-timeout==2.2.0 \
  && python3 -m pip install pytest==8.1.1 \
+ && python3 -m pip install pytest-asyncio==1.1.0 \
  && python3 -m pip install pytest-rerunfailures==13.0 \
  && python3 -m pip install mock==5.1.0 \
  && python3 -m pip install pymongo \
+ && python3 -m pip install aiokafka==0.12.0 \
  && python3 -m pip install requests
 
 COPY ./apply-patches.sh  /tmp/


### PR DESCRIPTION
# Description:

As mentioned in https://github.com/kytos-ng/kafka_events/pull/13 and https://github.com/kytos-ng/kytos-end-to-end-tests/pull/368, end-to-end testing needs to be done. To accomplish this, I needed to import `kafka_events` into the Docker image here and pull it in `kytos-end-to-end-tests`.

# Changes

- Added kafka_events to Dockerfile for use in E2E testing
- Added `aiokafka==0.12.0` for use when testing in container