### PR TITLE
Integrate Kytos docker with Noviflow and Telemetry INT

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,6 +42,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         openvswitch-switch mininet iputils-ping vim tmux less python3-paramiko openssh-client tini python3-scapy tcpdump \
 	&& cd /tmp \
 	&& curl -LO https://github.com/amlight/ovs-ext-novi/releases/download/ovs-3.1.0-deb12/openvswitch-common_3.1.0-2+deb12u1.1_amd64.deb \
+        && curl -LO https://github.com/amlight/ovs-ext-novi/releases/download/ovs-3.1.0-deb12/openvswitch-switch_3.1.0-2+deb12u1.1_amd64.deb \
+        && curl -LO https://github.com/amlight/ovs-ext-novi/releases/download/ovs-3.1.0-deb12/python3-openvswitch_3.1.0-2+deb12u1.1_amd64.deb \
 	&& dpkg -i *.deb \
 	&& apt-get clean \
 	&& rm -rf /var/lib/apt/lists/* /tmp/*


### PR DESCRIPTION
Related to https://github.com/kytos-ng/kytos-end-to-end-tests/issues/200
Related to https://github.com/kytos-ng/kytos-end-to-end-tests/pull/414

## Description of the changes

- Replace `openvswitch-common` package with a modified version that supports Noviflow Experimenter Actions (INT push, Add Metadata, Send report, POP INT). This will be necessary for new end-to-end tests being added for Telemetry INT (https://github.com/kytos-ng/kytos-end-to-end-tests/pull/415)
- Adding Kytos Napps `noviflow` and `telemetry_int`
- Adding packages `openssh-client` and `python3-paramiko` two dependencies that will be necessary for Mininet NoviSwitch backend.

## Local tests

```
> git status
On branch italovalcy-patch-1
Your branch is up to date with 'origin/italovalcy-patch-1'.

nothing to commit, working tree clean

$ git log -1
commit 58ff583a59d28f5cdf52dba42766a87dc3cb27ef (HEAD -> italovalcy-patch-1, origin/italovalcy-patch-1)
Author: Italo Valcy <italovalcy@gmail.com>
Date:   Thu Dec 11 16:58:48 2025 -0300

$ docker build -t amlight/kytos --pull .
[+] Building 115.3s (28/28) FINISHED                                                                                                                                                                                                         docker:default
 => [internal] load build definition from Dockerfile                                                                                                                                                                                                   0.2s
 => => transferring dockerfile: 4.71kB                                                                                                                                                                                                                 0.0s
 => [internal] load metadata for docker.io/library/debian:bookworm-slim                                                                                                                                                                                0.6s
 => [internal] load metadata for docker.io/library/node:lts-alpine                                                                                                                                                                                     0.6s
 => [auth] library/debian:pull token for registry-1.docker.io                                                                                                                                                                                          0.0s
 => [auth] library/node:pull token for registry-1.docker.io                                                                                                                                                                                            0.0s
 => [internal] load .dockerignore                                                                                                                                                                                                                      0.2s
 => => transferring context: 2B                                                                                                                                                                                                                        0.0s
 => [internal] load build context                                                                                                                                                                                                                      0.3s
 => => transferring context: 4.08kB                                                                                                                                                                                                                    0.0s
 => [ui-builder 1/4] FROM docker.io/library/node:lts-alpine@sha256:682368d8253e0c3364b803956085c456a612d738bd635926d73fa24db3ce53d7                                                                                                                    0.0s
 => [stage-1  1/17] FROM docker.io/library/debian:bookworm-slim@sha256:e899040a73d36e2b36fa33216943539d9957cba8172b858097c2cabcdb20a3e2                                                                                                                0.0s
 => CACHED [stage-1  2/17] RUN apt-get update && apt-get install -y --no-install-recommends  python3-setuptools python3-pip orphan-sysvinit-scripts rsyslog iproute2 procps curl jq git-core patch         openvswitch-switch mininet iputils-ping vi  0.0s
 => CACHED [stage-1  3/17] RUN rm /usr/lib/python3.11/EXTERNALLY-MANAGED                                                                                                                                                                               0.0s
 => CACHED [stage-1  4/17] RUN sed -i '/imklog/ s/^/#/' /etc/rsyslog.conf                                                                                                                                                                              0.0s
 => CACHED [stage-1  5/17] RUN git config --global url."https://github.com".insteadOf git://github.com                                                                                                                                                 0.0s
 => CACHED [stage-1  6/17] RUN python3 -m pip install setuptools==69.1.1                                                                                                                                                                               0.0s
 => CACHED [stage-1  7/17] RUN python3 -m pip install pip==24.0                                                                                                                                                                                        0.0s
 => CACHED [stage-1  8/17] RUN python3 -m pip install wheel==0.42.0                                                                                                                                                                                    0.0s
 => CACHED [stage-1  9/17] RUN python3 -m pip install https://github.com/kytos-ng/python-openflow/archive/master.zip  && python3 -m pip install https://github.com/kytos-ng/kytos-utils/archive/master.zip  && python3 -m pip install https://github.  0.0s
 => CACHED [ui-builder 2/4] WORKDIR /app                                                                                                                                                                                                               0.0s
 => CACHED [ui-builder 3/4] RUN apk add --no-cache git                                                                                                                                                                                                 0.0s
 => CACHED [ui-builder 4/4] RUN git clone -b master --single-branch https://github.com/kytos-ng/ui  && cd ui  && if [ "yes" == "yes" ]; then sed -ri 's/"version": "[^"]+"/"version": "Commit-'$(git log -1 --pretty=format:%h)'"/g' ./package.json;   0.0s
 => [stage-1 10/17] RUN python3 -m pip install -e git+https://github.com/kytos-ng/of_core@master#egg=kytos-of_core  && python3 -m pip install -e git+https://github.com/kytos-ng/flow_manager@master#egg=kytos-flow_manager  && python3 -m pip insta  83.2s
 => [stage-1 11/17] COPY --from=ui-builder /app/ui/web-ui /usr/local/lib/python3.11/dist-packages/kytos/web-ui                                                                                                                                         1.3s
 => [stage-1 12/17] RUN python3 -m pip install pytest-timeout==2.2.0  && python3 -m pip install pytest==8.1.1  && python3 -m pip install pytest-asyncio==1.1.0  && python3 -m pip install pytest-rerunfailures==13.0  && python3 -m pip install mock  15.7s
 => [stage-1 13/17] COPY ./apply-patches.sh  /tmp/                                                                                                                                                                                                     1.0s
 => [stage-1 14/17] COPY ./patches /tmp/patches                                                                                                                                                                                                        1.0s
 => [stage-1 15/17] RUN cd /tmp && ./apply-patches.sh && rm -rf /tmp/*                                                                                                                                                                                 3.9s
 => [stage-1 16/17] COPY docker-entrypoint.sh /docker-entrypoint.sh                                                                                                                                                                                    1.1s
 => exporting to image                                                                                                                                                                                                                                 6.1s
 => => exporting layers                                                                                                                                                                                                                                5.7s
 => => writing image sha256:22b78e6055a59f0dd7d138fb15150328ba563236ef46d30580428149e98d9f01                                                                                                                                                           0.0s
 => => naming to docker.io/amlight/kytos
```